### PR TITLE
fix(native): explicitly declare JBoss Logging dependency

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,13 +9,14 @@ services:
     ports:
       - "5432:5432"
   app-jvm:
-    image: rweekers/voornameninliedjes-backend:3.3.0-jvm
-    user: ${UID}:${GID}
+    image: rweekers/voornameninliedjes-backend:3.4.3-jvm
+    user: ${MY_UID}:${MY_GID}
     restart: unless-stopped
     environment:
       SPRING_PROFILES_ACTIVE: dev
       LOG_PATH: /workspace/logs
       CONTAINER: jvm
+      LASTFM_API_KEY: ${LASTFM_API_KEY}
       voornameninliedjes.datasource.application.jdbcUrl: jdbc:postgresql://db:5432/voornameninliedjes
       voornameninliedjes.datasource.migration.jdbcUrl: jdbc:postgresql://db:5432/voornameninliedjes
       voornameninliedjes.images.service.path: http://localhost:8000/images/
@@ -24,17 +25,18 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - "./logs-docker:/workspace/logs"
-      - "./images:/workspace/images"
+      - "./logs-docker:/workspace/logs:Z"
+      - "./images:/workspace/images:Z"
     depends_on:
       - db
   app-native:
-    image: rweekers/voornameninliedjes-backend:3.3.0-native
-    user: ${UID}:${GID}
+    image: rweekers/voornameninliedjes-backend:3.4.3-native
+    user: ${MY_UID}:${MY_GID}
     restart: unless-stopped
     environment:
       SPRING_PROFILES_ACTIVE: dev
       LOG_PATH: /workspace/logs
+      LASTFM_API_KEY: ${LASTFM_API_KEY}
       server.port: 9000
       voornameninliedjes.datasource.application.jdbcUrl: jdbc:postgresql://db:5432/voornameninliedjes
       voornameninliedjes.datasource.migration.jdbcUrl: jdbc:postgresql://db:5432/voornameninliedjes
@@ -44,8 +46,8 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      - "./logs-docker:/workspace/logs"
-      - "./images:/workspace/images"
+      - "./logs-docker:/workspace/logs:Z"
+      - "./images:/workspace/images:Z"
     depends_on:
       - db
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     </parent>
     <groupId>nl.orangeflamingo</groupId>
     <artifactId>voornameninliedjes-backend</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <name>Voornameninliedjes Backend</name>
     <description>Backend service voor voornamen in liedjes</description>
     <url>https://voornameninliedjes.nl</url>
@@ -63,6 +63,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Explicit declaration required for GraalVM native image -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jdbc</artifactId>


### PR DESCRIPTION
Ensure JBoss Logging is included correctly in GraalVM native images. Without the explicit dependency, Hibernate Validator fails to initialize at runtime because its logger implementation cannot be found.